### PR TITLE
Fix sound related crashes on WIndows 8.1

### DIFF
--- a/Source/gg2/Scripts/Sound/playsound.gml
+++ b/Source/gg2/Scripts/Sound/playsound.gml
@@ -4,7 +4,7 @@
     if(vol==0) exit;
     
     // Prevent crashes on Win8 (NT Kernel 6.2)
-    if (global.NTKernelVersion == 6.2 || global.forceAudioFix)
+    if (global.NTKernelVersion == 6.2 || global.NTKernelVersion == 6.3 || global.forceAudioFix)
         sound_stop(argument2);
     
     sound_volume(argument2, vol);


### PR DESCRIPTION
This was due to an error not found in the beta. Fixes https://github.com/Gang-Garrison-2/Gang-Garrison-2/issues/224