### PR TITLE
Do not allow BassieFace bubble on other days

### DIFF
--- a/Source/gg2/Scripts/GameServer/processClientCommands.gml
+++ b/Source/gg2/Scripts/GameServer/processClientCommands.gml
@@ -198,6 +198,10 @@ while(commandLimitRemaining > 0) {
             {
                 bubbleImage = 61;
             }
+            else if (bubbleImage == 61 and !global.aFirst) {
+            	// Player sent an april fools bubble on another day
+            	break;
+            }
             write_ubyte(global.sendBuffer, CHAT_BUBBLE);
             write_ubyte(global.sendBuffer, playerId);
             write_ubyte(global.sendBuffer, bubbleImage);


### PR DESCRIPTION
This might happen if players use a client-side plugin, so avoid trolling possibilities server-side
Note: I did **not** test this because it should be fairly straightforward, also I'm using Ubuntu and haven't set up Wine so it was kind of a hassle