### PR TITLE
Use .gitattributes to force the equivalent of core.autocrlf=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# This “unsets” the git “text” attribute on all files, which tells git to
+# not do any line-ending conversion between LF and CRLF on check-in and
+# check-out. This is like core.autocrlf=false, but doesn't require the user to
+# edit their git config, instead it overrides it.
+* -text

--- a/Contributing.md
+++ b/Contributing.md
@@ -20,11 +20,14 @@ Gang Garrison 2 is built with Game Maker 8.0 Pro, so you will need that for most
 Git Setup
 ---------
 
-This repository requires you to have `core.autocrlf` set to `false`, so make sure you do this when you first clone it:
+This repository now contains a `.gitattributes` file that tells git not to mess
+with line endings, but this is a recent addition. You may want to set the
+`core.autocrlf` configuration key to `false` if you're going to check out
+previous versions of the repository (including forks/mods of old versions):
 
     git config --local core.autocrlf false
 
-Otherwise, you'll screw up the line endings.
+Otherwise, git may fight you over line endings, which is never fun.
 
 GmkSplitter
 -----------


### PR DESCRIPTION
See the discussion in https://github.com/Gang-Garrison-2/Gang-Garrison-2/pull/242#issuecomment-664826881 for the background to this.

This PR includes an equivalent `.gitattributes` change (this version uses the modern syntax) to what @cher-nov proposed, but does not do a sweeping line-ending normalisation of the existing files. This PR just tells git via `.gitattributes` to not touch the line endings, matching what we've always asked contributors to put in their `git config`. As a result, new contributors don't have to edit their `git config` for git to behave properly. Because it matches our existing `git config` practice, this `.gitattributes` change doesn't cause git to see any diffs from previous versions (yes, I made sure to `touch`). ![:z6:](https://static.ganggarrison.com/Smileys/classic/z6.png)

(The first version of this description misunderstood @cher-nov's PR, so this description has been edited.)

By the way, you may want to look at my list of which files in GG2 use CRLF versus LF. We actually have far more LF than CRLF files. https://gist.github.com/hikari-no-yume/1367be8ea2aa98db6d202e205bdb0eba