### PR TITLE
Fix getRelativePathIfDescendant script name

### DIFF
--- a/Source/gg2/Objects/Menus/Hosting Menu Elements/AdvHostOptionsController.events/Create.xml
+++ b/Source/gg2/Objects/Menus/Hosting Menu Elements/AdvHostOptionsController.events/Create.xml
@@ -31,7 +31,7 @@ menu_addedit_script("Map Rotation:", menu_format_maprotation_filepath(global.map
     if (absPath == "") {
         global.mapRotationFile = absPath;
     } else {
-        global.mapRotationFile = getRelativePathIfDescendand(working_directory + "\", absPath);
+        global.mapRotationFile = getRelativePathIfDescendant(working_directory + "\", absPath);
     }
     
     gg2_write_ini("Server", "MapRotation", global.mapRotationFile);

--- a/Source/gg2/Scripts/Misc/_resources.list.xml
+++ b/Source/gg2/Scripts/Misc/_resources.list.xml
@@ -11,5 +11,5 @@
   <resource name="initCharacterSpritePrefixes" type="RESOURCE"/>
   <resource name="getCharacterSpriteId" type="RESOURCE"/>
   <resource name="format_timer_value" type="RESOURCE"/>
-  <resource name="getRelativePathIfDescendand" type="RESOURCE"/>
+  <resource name="getRelativePathIfDescendant" type="RESOURCE"/>
 </resources>

--- a/Source/gg2/Scripts/Misc/getRelativePathIfDescendant.gml
+++ b/Source/gg2/Scripts/Misc/getRelativePathIfDescendant.gml
@@ -1,4 +1,4 @@
-// getRelativePathIfDescendand(startPath, endPath)
+// getRelativePathIfDescendant(startPath, endPath)
 // Determines a relative path for endPath that is relative to startPath, if endPath is inside of startPath or a subdirectory of startPath.
 // Otherwise returns endPath as an absolute path.
 // startPath and endPath must be absolute paths.


### PR DESCRIPTION
There are no plugins that I know of that make use of this script, as it's fairly new, so we can safely rename it