### PR TITLE
Simplify classname.gml

### DIFF
--- a/Source/gg2/Scripts/Misc/classname.gml
+++ b/Source/gg2/Scripts/Misc/classname.gml
@@ -2,22 +2,17 @@
 //Example: classname(CLASS_SPY) - Returns "Infiltrator"
 //Returns: Gang Garrison 2 name of the class (By ID/constant)
 
-var classStr, class;
-classStr = "Unknown";
-class = argument0;
-
-switch (class)
+switch (argument0)
 {
-    case CLASS_SCOUT: classStr = "Runner"; break;
-    case CLASS_SOLDIER: classStr = "Rocketman"; break;
-    case CLASS_SNIPER: classStr = "Rifleman"; break;
-    case CLASS_DEMOMAN: classStr = "Detonator"; break;
-    case CLASS_MEDIC: classStr = "Healer"; break;
-    case CLASS_ENGINEER: classStr = "Constructor"; break;
-    case CLASS_HEAVY: classStr = "Overweight"; break;
-    case CLASS_SPY: classStr = "Infiltrator"; break;
-    case CLASS_PYRO: classStr = "Firebug"; break;
-    case CLASS_QUOTE: classStr = "Querly"; break;
+    case CLASS_SCOUT: return "Runner";
+    case CLASS_SOLDIER: return "Rocketman";
+    case CLASS_SNIPER: return "Rifleman";
+    case CLASS_DEMOMAN: return "Detonator";
+    case CLASS_MEDIC: return "Healer";
+    case CLASS_ENGINEER: return "Constructor";
+    case CLASS_HEAVY: return "Overweight";
+    case CLASS_SPY: return "Infiltrator";
+    case CLASS_PYRO: return "Firebug";
+    case CLASS_QUOTE: return "Querly";
+    default: return "Unknown";
 }
-
-return classStr;


### PR DESCRIPTION
There's no real reason to assign variables here. GML isn't compiled, so assigning variables has a microscopic performance drop, which is undesirable for hot code like text rendering - the primary use-case for this function.