### PR TITLE
Prevent DeadGuy from spamming ImpactSnd

### DIFF
--- a/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
+++ b/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
@@ -28,12 +28,14 @@ if(place_free(x,y+1))
     {
         vspeed=10;
     }
+    hitground = true;
 }
 else
 {
     if (!hitground)
     {
-        playsound(x,y,ImpactSnd);
+        if (vspeed >= 1.2)
+           playsound(x,y,ImpactSnd);
         hitground = true;
     }
     vspeed = 0;

--- a/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
+++ b/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
@@ -28,7 +28,7 @@ if(place_free(x,y+1))
     {
         vspeed=10;
     }
-    hitground = true;
+    hitground = false;
 }
 else
 {

--- a/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
+++ b/Source/gg2/Objects/InGameElements/DeadGuy.events/Step.xml
@@ -28,7 +28,6 @@ if(place_free(x,y+1))
     {
         vspeed=10;
     }
-    hitground = false;
 }
 else
 {


### PR DESCRIPTION
When sliding down stairs, the DeadGuy will play ImpactSnd repeatedly. Removing the line which unsets the "hitground" flag will stop this phenomenon.