### PR TITLE
Fix end game music for spectator

### DIFF
--- a/Source/gg2/Objects/Overlays/WinBanner.events/Create.xml
+++ b/Source/gg2/Objects/Overlays/WinBanner.events/Create.xml
@@ -35,6 +35,13 @@ with (Player) {
         humiliated = 1;
     }
 }
+          
+//Round end audio from spectator's perspective
+if (global.myself.team == TEAM_SPECTATOR)
+    if (global.winners == TEAM_SPECTATOR)
+        sound = FailureSnd; //Stalemate (Everybody loses)
+    else
+        sound = VictorySnd; //RED/BLU Victory
 
 if(!instance_exists(ArenaHUD)) {
     AudioControlPlaySong(sound, false);


### PR DESCRIPTION
Added an extra few lines of code to WinBanner's create event to fix the bug where spectators would always hear FailureSnd if RED/BLU won, but VictorySnd during a stalemate. This behavior seems completely backwards.
Now spectators observing a round end will hear VictorySnd whenever either team wins, except during a stalemate, where the spectator shall hear FailureSnd like everyone else.