### PR TITLE
Move some execute_string calls to asset_get_index

### DIFF
--- a/Source/gg2/Scripts/Menus/menu_get_var.gml
+++ b/Source/gg2/Scripts/Menus/menu_get_var.gml
@@ -1,3 +1,3 @@
 // Find the value of the tied variable for an item
 // argument0: item number
-return execute_string("return "+item_var[argument0]);
+return asset_get_index(item_var[argument0]);

--- a/Source/gg2/Scripts/Misc/_resources.list.xml
+++ b/Source/gg2/Scripts/Misc/_resources.list.xml
@@ -12,4 +12,5 @@
   <resource name="getCharacterSpriteId" type="RESOURCE"/>
   <resource name="format_timer_value" type="RESOURCE"/>
   <resource name="getRelativePathIfDescendant" type="RESOURCE"/>
+  <resource name="asset_get_index" type="RESOURCE"/>
 </resources>

--- a/Source/gg2/Scripts/Misc/asset_get_index.gml
+++ b/Source/gg2/Scripts/Misc/asset_get_index.gml
@@ -1,0 +1,5 @@
+// Returns the unique identifying index for a game asset from its name (aka the actual resource)
+// You should always make sure that an asset with that name exists, otherwise it will crash.
+// argument0: The name of the game asset to get the index of (a string)
+return execute_string("return " + argument0);
+

--- a/Source/gg2/Scripts/Misc/getCharacterSpriteId.gml
+++ b/Source/gg2/Scripts/Misc/getCharacterSpriteId.gml
@@ -20,4 +20,4 @@ if(!is_string(team))
         show_error("Attempted to get a sprite for unknown team ID: " + string(team), true);
 }
 
-return execute_string("return " + class + team + animation + "S;");
+return asset_get_index(class + team + animation + "S");


### PR DESCRIPTION
This is meant to isolate 2 execute_string calls into their own script, as well as to clarify what it actually does. I remember being confused when I read that code when I first started working on GG2.