### PR TITLE
Fix missing view index in ParallaxController/Draw

### DIFF
--- a/Source/gg2/Objects/InGameElements/ParallaxController.events/Draw.xml
+++ b/Source/gg2/Objects/InGameElements/ParallaxController.events/Draw.xml
@@ -23,7 +23,7 @@ draw_set_color(voidColor);
 if (view_yview[0] &lt; 0)
     draw_rectangle(view_xview[0], view_yview[0], view_xview[0]+view_wview[0], 0, false);
 if (view_yview[0]+view_hview[0] &gt; map_height())
-    draw_rectangle(view_xview[0], view_yview[0]+view_hview[], view_xview[0]+view_wview[0], map_height(), false);
+    draw_rectangle(view_xview[0], view_yview[0]+view_hview[0], view_xview[0]+view_wview[0], map_height(), false);
 if (view_xview[0] &lt; 0)
     draw_rectangle(view_xview[0], view_yview[0], 0, view_yview[0]+view_hview[0], false);
 if (view_xview[0]+view_wview[0] &gt; map_width())


### PR DESCRIPTION
This (99% sure) didn't cause any error or bug in GM8 or GMS, but GMS2 doesn't like it.
In any case, it's weird to have an array access without an index