### PR TITLE
asset_get_index fix and security check

### DIFF
--- a/Source/gg2/Scripts/Menus/menu_get_var.gml
+++ b/Source/gg2/Scripts/Menus/menu_get_var.gml
@@ -1,3 +1,3 @@
 // Find the value of the tied variable for an item
 // argument0: item number
-return asset_get_index(item_var[argument0]);
+return execute_string("return " + item_var[argument0]);

--- a/Source/gg2/Scripts/Misc/asset_get_index.gml
+++ b/Source/gg2/Scripts/Misc/asset_get_index.gml
@@ -1,5 +1,15 @@
 // Returns the unique identifying index for a game asset from its name (aka the actual resource)
 // You should always make sure that an asset with that name exists, otherwise it will crash.
 // argument0: The name of the game asset to get the index of (a string)
+
+// Check for possible malformed string or code injection
+// Only allow _ as special character
+var checkstr;
+checkstr = string_replace_all(argument0, "_", "");
+if (checkstr != string_lettersdigits(argument0)) {
+    show_error("Invalid variable name [" + argument0 + "] for asset_get_index", false);
+    exit;
+}
+
 return execute_string("return " + argument0);
 


### PR DESCRIPTION
While using asset_get_index in menu_get_var was working, it only did so because of the execute_string
I wasn't differentiating between dealing with resources and dealing with variables