### PR TITLE
Fix multi-client limit kick message not being received

### DIFF
--- a/Source/gg2/Scripts/GameServer/acceptJoiningPlayer.gml
+++ b/Source/gg2/Scripts/GameServer/acceptJoiningPlayer.gml
@@ -2,8 +2,9 @@ var joiningSocket, joiningPlayer, totalClientNumber;
 joiningSocket = socket_accept(global.tcpListener);
 if (joiningSocket >= 0)
 {
-    var ip;
+    var ip, kicked;
     ip = socket_remote_ip(joiningSocket);
+    kicked = false;
 
     // Only enforce multiclient limit for non-localhost connections
     if (ip != '127.0.0.1' and ip != '::1')
@@ -28,11 +29,11 @@ if (joiningSocket >= 0)
             write_ubyte(joiningSocket, KICK);
             write_ubyte(joiningSocket, KICK_MULTI_CLIENT);
             socket_send(joiningSocket);
-            socket_destroy(joiningSocket);
-            exit;
+            kicked = true;
         }
     }
     
     joiningPlayer = instance_create(0,0,JoiningPlayer);
     joiningPlayer.socket = joiningSocket;
+    joiningPlayer.kicked = kicked;
 }


### PR DESCRIPTION
The socket_destroy call here prevents the client from ever receiving the reason for their disconnect, leading to them getting the "Unable to connect" message instead of the intended message.