### PR TITLE
Fix TeamDeathmatchHUD overlapping the scoreboard

### DIFF
--- a/Source/gg2/Objects/Overlays/Gamemodes/TeamDeathmatchHUD.xml
+++ b/Source/gg2/Objects/Overlays/Gamemodes/TeamDeathmatchHUD.xml
@@ -3,7 +3,7 @@
   <sprite>TeamDeathmatchHUDS</sprite>
   <solid>false</solid>
   <visible>true</visible>
-  <depth>-120000</depth>
+  <depth>-110000</depth>
   <persistent>false</persistent>
   <parent>HUD</parent>
   <mask/>


### PR DESCRIPTION
Follow-up of 4d10b7d8d10c2c90858b7de5b655c0af4ad9434a.
For some reason the depth value change was missed in this case. Accidentally, I believe.
But maybe @wareya knows more.

![2025-05-27 20-20-59 My Server tdm_mantic](https://github.com/user-attachments/assets/30f3f608-fdd0-4a20-b2b3-7bcbce41f8fc)
